### PR TITLE
Add GitHub Action to create new repo based on input repoUrl

### DIFF
--- a/.github/workflows/create-repo.yml
+++ b/.github/workflows/create-repo.yml
@@ -1,0 +1,37 @@
+name: Create New Repo
+
+on:
+  workflow_dispatch:
+    inputs:
+      repoUrl:
+        description: 'The GitHub repository URL in HTTPS format'
+        required: true
+      branchName:
+        description: 'The branch name to use'
+        default: 'main'
+
+jobs:
+  create-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print input parameters
+        run: |
+          echo "repoUrl: ${{ github.event.inputs.repoUrl }}"
+          echo "branchName: ${{ github.event.inputs.branchName }}"
+
+      - name: Extract orgName and repoName
+        id: extract
+        run: |
+          orgName=$(echo "${{ github.event.inputs.repoUrl }}" | cut -d'/' -f4)
+          repoName=$(echo "${{ github.event.inputs.repoUrl }}" | cut -d'/' -f5 | cut -d'.' -f1)
+          echo "orgName=$orgName" >> $GITHUB_ENV
+          echo "repoName=$repoName" >> $GITHUB_ENV
+          docs_repo_name="${orgName}_${repoName}"
+          echo "docs_repo_name=$docs_repo_name" >> $GITHUB_ENV
+
+      - name: Create new repo
+        uses: peter-evans/create-or-update-repo@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ env.docs_repo_name }}
+          private: true

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
 # code2docs-ai-core
+
+## GitHub Action: Create New Repo
+
+This repository contains a GitHub Action workflow that allows you to create a new repository in the current organization based on an input repository URL.
+
+### Usage
+
+To use this GitHub Action workflow, follow these steps:
+
+1. Trigger the workflow with the following input parameters:
+   - `repoUrl`: The GitHub repository URL in HTTPS format.
+   - `branchName`: The branch name to use (default value is `main`).
+
+2. The workflow will perform the following steps:
+   - Print out the input parameters values in the workflow log.
+   - Extract the `orgName` and `repoName` from the `repoUrl`, and concatenate them to form another parameter `docs_repo_name` = `orgName_repoName`.
+   - Create a new repository in the current organization with the name `docs_repo_name`.
+
+### Example
+
+Here is an example of how to trigger the workflow:
+
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      repoUrl:
+        description: 'The GitHub repository URL in HTTPS format'
+        required: true
+      branchName:
+        description: 'The branch name to use'
+        default: 'main'
+```
+
+This will trigger the workflow and create a new repository in the current organization based on the input `repoUrl`.


### PR DESCRIPTION
Related to #1

Add a GitHub Action workflow to create a new repository in the current organization based on an input repository URL.

* **README.md**
  - Add a section to mention the new GitHub Action workflow and its usage.
  - Provide an example of how to trigger the workflow.

* **.github/workflows/create-repo.yml**
  - Create a new GitHub Action workflow file.
  - Add input parameters `repoUrl` and `branchName` with default value `main`.
  - Add steps to print the input parameters in the workflow log.
  - Add steps to extract `orgName` and `repoName` from `repoUrl` and concatenate them to form `docs_repo_name`.
  - Add steps to create a new repo in the current org with the name `docs_repo_name`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/code2docs-ai/code2docs-ai-core/pull/2?shareId=b423b85c-8059-421b-809e-1ebb55ee7bf5).