### PR TITLE
Fix GitHub Action to create new repo

### DIFF
--- a/.github/workflows/create-repo.yml
+++ b/.github/workflows/create-repo.yml
@@ -30,8 +30,10 @@ jobs:
           echo "docs_repo_name=$docs_repo_name" >> $GITHUB_ENV
 
       - name: Create new repo
-        uses: peter-evans/create-or-update-repo@v2
+        uses: peter-evans/create-or-update-repository@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ env.docs_repo_name }}
           private: true
+
+# Note: The workflow requires a `GITHUB_TOKEN` secret to authenticate and create the new repository.

--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ on:
 ```
 
 This will trigger the workflow and create a new repository in the current organization based on the input `repoUrl`.
+
+### Note
+
+The workflow requires a `GITHUB_TOKEN` secret to authenticate and create the new repository.


### PR DESCRIPTION
Related to #1

Update GitHub Action workflow to create a new repository in the current organization based on input `repoUrl` and `branchName`.

* **README.md**
  - Add a note about the required `GITHUB_TOKEN` secret to authenticate and create the new repository.

* **.github/workflows/create-repo.yml**
  - Update the action to `peter-evans/create-or-update-repository@v2`.
  - Add a note about the required `GITHUB_TOKEN` secret to authenticate and create the new repository.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/code2docs-ai/code2docs-ai-core/pull/3?shareId=f0d38f77-435e-4d70-ba4e-0de7b7a6a116).