### PR TITLE
Improve create-repo.yml by checking the Create new repo step to fail the job if the creation is failed

### DIFF
--- a/.github/workflows/create-repo.yml
+++ b/.github/workflows/create-repo.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Create new repo
         run: |
-          curl -X POST -H "Authorization: token ${{ secrets.MY_PAT }}" \
+          curl --fail -X POST -H "Authorization: token ${{ secrets.MY_PAT }}" \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/orgs/code2docs-ai/repos \
-          -d '{"name":"${{ env.docs_repo_name }}","private":false}'
+          -d '{"name":"${{ env.docs_repo_name }}","private":false}' || exit 1

--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ This will trigger the workflow and create a new repository in the current organi
 ### Note
 
 The workflow requires a `GITHUB_TOKEN` secret to authenticate and create the new repository.
+
+### Error Handling
+
+The `Create new repo` step includes error handling to ensure that the job fails if the repository creation fails. The `curl` command used to create the repository includes the `--fail` option to ensure it fails on error, and `|| exit 1` to exit the job if the repository creation fails.


### PR DESCRIPTION
Related to #6

Add error handling to the `Create new repo` step in the `.github/workflows/create-repo.yml` file.

* **.github/workflows/create-repo.yml**
  - Add `--fail` option to `curl` command to ensure it fails on error.
  - Add `|| exit 1` to the `curl` command to exit the job if the repository creation fails.

* **README.md**
  - Add a note about error handling for the repository creation step.
  - Mention that the job will fail if the repository creation fails.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/code2docs-ai/code2docs-ai-core/pull/7?shareId=49a7a209-f02d-4f09-955d-2ff01a034c44).