### PR TITLE
Improve create-repo.yml by adding validation for repoUrl

### DIFF
--- a/.github/workflows/create-repo.yml
+++ b/.github/workflows/create-repo.yml
@@ -19,6 +19,13 @@ jobs:
           echo "repoUrl: ${{ github.event.inputs.repoUrl }}"
           echo "branchName: ${{ github.event.inputs.branchName }}"
 
+      - name: Validate repoUrl
+        run: |
+          if [[ "${{ github.event.inputs.repoUrl }}" != https://github.com/* ]]; then
+            echo "Error: repoUrl must be a GitHub.com address and a HTTPS address."
+            exit 1
+          fi
+
       - name: Extract orgName and repoName
         id: extract
         run: |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ To use this GitHub Action workflow, follow these steps:
 
 2. The workflow will perform the following steps:
    - Print out the input parameters values in the workflow log.
+   - Validate that the `repoUrl` is a GitHub.com address and a HTTPS address. If not, the job will fail.
    - Extract the `orgName` and `repoName` from the `repoUrl`, and concatenate them to form another parameter `docs_repo_name` = `orgName_repoName`.
    - Check if the repository `docs_repo_name` exists using the GitHub API.
    - If the repository exists, delete it before creating a new one.


### PR DESCRIPTION
Related to #13

Add validation for `repoUrl` in `create-repo.yml` workflow.

* **Validation Step**: Add a step to validate that `repoUrl` starts with "https://github.com/". If not, the job fails with an appropriate error message.
* **README Update**: Update `README.md` to include information about the new validation step for `repoUrl`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/code2docs-ai/code2docs-ai-core/pull/14?shareId=d4f22cc5-6c28-49fe-ae1c-1aebfda89ca0).