### PR TITLE
Improve create-repo.yml by validating the repoUrl exists on github.com and is publicly accessible

### DIFF
--- a/.github/workflows/create-repo.yml
+++ b/.github/workflows/create-repo.yml
@@ -25,6 +25,12 @@ jobs:
             echo "Error: repoUrl must be a GitHub.com address and a HTTPS address."
             exit 1
           fi
+          repo_status=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: token ${{ secrets.MY_PAT }}" \
+          "${{ github.event.inputs.repoUrl }}")
+          if [[ "$repo_status" != "200" ]]; then
+            echo "Error: repoUrl does not exist on GitHub or is not publicly accessible."
+            exit 1
+          fi
 
       - name: Extract orgName and repoName
         id: extract

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ To use this GitHub Action workflow, follow these steps:
 2. The workflow will perform the following steps:
    - Print out the input parameters values in the workflow log.
    - Validate that the `repoUrl` is a GitHub.com address and a HTTPS address. If not, the job will fail.
+   - Validate that the `repoUrl` exists on GitHub and is publicly accessible. If not, the job will fail.
    - Extract the `orgName` and `repoName` from the `repoUrl`, and concatenate them to form another parameter `docs_repo_name` = `orgName_repoName`.
    - Check if the repository `docs_repo_name` exists using the GitHub API.
    - If the repository exists, delete it before creating a new one.
@@ -47,6 +48,8 @@ The workflow requires a `GITHUB_TOKEN` secret to authenticate and create the new
 The `Create new repo` step includes error handling to ensure that the job fails if the repository creation fails. The `curl` command used to create the repository includes the `--fail` option to ensure it fails on error, and `|| exit 1` to exit the job if the repository creation fails.
 
 Additionally, the workflow now includes validation to check if the repository `docs_repo_name` exists before attempting to create it. If the repository exists, it will be deleted before creating a new one. This ensures that the repository creation process does not fail due to an existing repository with the same name.
+
+The workflow also includes validation to check if the `repoUrl` exists on GitHub and is publicly accessible. If the `repoUrl` does not exist or is not publicly accessible, the job will fail. This ensures that the repository creation process does not fail due to an invalid or inaccessible `repoUrl`.
 
 ### Created by code2repo ai
 


### PR DESCRIPTION
Related to #15

Update `create-repo.yml` to validate the existence and public accessibility of `repoUrl`.

* **README.md**
  - Add a step to validate that the `repoUrl` exists on GitHub and is publicly accessible in the "Usage" section.
  - Update the "Error Handling" section to mention the validation for the existence and public accessibility of the `repoUrl`.

* **.github/workflows/create-repo.yml**
  - Add a step to validate the existence and public accessibility of the `repoUrl` using GitHub API.
  - Update the "Validate repoUrl" step to include the new validation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/code2docs-ai/code2docs-ai-core/pull/16?shareId=0627bb92-3f86-48ab-bc39-77b4d428b71c).