### PR TITLE
Add cleanup step to create-repo.yml

### DIFF
--- a/.github/workflows/create-repo.yml
+++ b/.github/workflows/create-repo.yml
@@ -14,6 +14,10 @@ jobs:
   create-repo:
     runs-on: self-hosted
     steps:
+      - name: Clean up working directory
+        run: |
+          rm -rf *
+
       - name: Print input parameters
         run: |
           echo "repoUrl: ${{ github.event.inputs.repoUrl }}"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ To use this GitHub Action workflow, follow these steps:
    - Create a new repository in the current organization with the name `docs_repo_name` using the GitHub API.
    - Check if the local directory already exists and remove it if it exists before cloning the repository.
    - Clone the source from `repoUrl` at the end of the workflow.
+   - Clean up the working directory on the runner before running any steps.
 
 ### Example
 


### PR DESCRIPTION
Related to #21

Add a cleanup step to the `create-repo.yml` workflow to clean up the working directory on the runner before running any steps.

* **README.md**
  - Add a note about the new cleanup step in the workflow.

* **.github/workflows/create-repo.yml**
  - Add a new step to clean up the working directory before the "Print input parameters" step.
  - Use the `run` command to remove any existing files or directories in the working directory.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/code2docs-ai/code2docs-ai-core/pull/22?shareId=0d7823e0-f9cd-4d7a-a7d2-7002108ab745).