### PR TITLE
Improve create-repo.yml workflow by adding aise-cli repo parse-repo step at the end

### DIFF
--- a/.github/workflows/create-repo.yml
+++ b/.github/workflows/create-repo.yml
@@ -92,3 +92,19 @@ jobs:
           cd source_repo
           git remote add new_repo https://code2docs-ai:${{ secrets.MY_PAT }}@github.com/code2docs-ai/${{ env.docs_repo_name }}.git
           git push new_repo ${{ github.event.inputs.branchName }}
+
+      - name: Activate python environment
+        run: |
+          source ~/source/aise-cli/.venv/bin/activate
+
+      - name: Run aise-cli command
+        run: |
+          aise-cli
+
+      - name: Delete source repo
+        run: |
+          aise-cli repo delete-repo source_repo
+
+      - name: Parse repo
+        run: |
+          aise-cli repo parse-repo --repo_name ${{ github.workspace }}/source_repo

--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ Additionally, the workflow now includes validation to check if the repository `d
 
 The workflow also includes validation to check if the `repoUrl` exists on GitHub and is publicly accessible. If the `repoUrl` does not exist or is not publicly accessible, the job will fail. This ensures that the repository creation process does not fail due to an invalid or inaccessible `repoUrl`.
 
+### Additional Steps
+
+The workflow now includes additional steps to activate the python environment, run the 'aise-cli' command, and parse the repo using 'aise-cli repo parse-repo':
+
+1. Activate the python environment:
+   ```shell
+   source ~/source/aise-cli/.venv/bin/activate
+   ```
+
+2. Run the 'aise-cli' command to test if the python environment works:
+   ```shell
+   aise-cli
+   ```
+
+3. Delete the source repo and parse the repo using 'aise-cli repo parse-repo':
+   ```shell
+   # delete source repo
+   aise-cli repo delete-repo source_repo
+   # parse repo
+   aise-cli repo parse-repo --repo_path  aise-cli repo parse-repo --repo_name <source_repo absolute>
+   ```
+
 ### Created by code2repo ai
 
 This repository was created by code2repo ai.


### PR DESCRIPTION
Related to #23

Add steps to activate python environment, run 'aise-cli' command, and parse repo in `create-repo.yml` workflow.

* **README.md**
  - Add a new section to describe the new steps added to the workflow.
  - Mention the activation of the python environment.
  - Mention running the 'aise-cli' command.
  - Mention parsing the repo using 'aise-cli repo parse-repo'.

* **.github/workflows/create-repo.yml**
  - Add a step to activate the python environment using `source ~/source/aise-cli/.venv/bin/activate`.
  - Add a step to run the 'aise-cli' command to test if the python environment works.
  - Add a step to delete the source repo using `aise-cli repo delete-repo source_repo`.
  - Add a step to parse the repo using `aise-cli repo parse-repo --repo_name ${{ github.workspace }}/source_repo`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/code2docs-ai/code2docs-ai-core/pull/24?shareId=90aa6f92-c772-40f4-99f2-de1bcb3da86e).