### PR TITLE
Improve create-repo.yml by using the input parameter branchName to determine which branch to clone

### DIFF
--- a/.github/workflows/create-repo.yml
+++ b/.github/workflows/create-repo.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Clone the source from repoUrl
         run: |
-          git clone ${{ github.event.inputs.repoUrl }} ${{ env.repoName }}
+          git clone --branch ${{ github.event.inputs.branchName }} ${{ github.event.inputs.repoUrl }} ${{ env.repoName }}
           cd ${{ env.repoName }}
 
       - name: Run aise-cli
@@ -105,4 +105,3 @@ jobs:
           git add .
           git commit -m "Generate document for ${{ env.repoName }}"
           git push https://code2docs-ai:${{ secrets.MY_PAT }}@github.com/code2docs-ai/${{ env.docs_repo_name }}.git main
-

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To use this GitHub Action workflow, follow these steps:
    - If the repository exists, delete it before creating a new one.
    - Create a new repository in the current organization with the name `docs_repo_name` using the GitHub API.
    - Check if the local directory already exists and remove it if it exists before cloning the repository.
-   - Clone the source from `repoUrl` at the end of the workflow.
+   - Clone the source from `repoUrl` at the end of the workflow, using the `branchName` input parameter to specify which branch to clone.
    - Clean up the working directory on the runner before running any steps.
 
 ### Example


### PR DESCRIPTION
Related to #25

Update the `create-repo.yml` workflow to use the `branchName` input parameter for cloning a specific branch.

* **README.md**
  - Update the usage section to explain the usage of the `branchName` input parameter in cloning a specific branch.

* **.github/workflows/create-repo.yml**
  - Update the `Clone the source from repoUrl` step to include the `--branch` option to clone the specified branch.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/code2docs-ai/code2docs-ai-core/pull/26?shareId=7b9db969-af2b-4f1c-b57a-238a4482b585).