### PR TITLE
Add functionality to store workflow runs state in JSON file

### DIFF
--- a/.github/workflows/create-repo.yml
+++ b/.github/workflows/create-repo.yml
@@ -105,3 +105,24 @@ jobs:
           git add .
           git commit -m "Generate document for ${{ env.repoName }}"
           git push https://code2docs-ai:${{ secrets.MY_PAT }}@github.com/code2docs-ai/${{ env.docs_repo_name }}.git main
+
+      - name: Clone the current repository
+        run: |
+          git clone https://github.com/${{ github.repository }}.git
+          cd ${{ github.repository }}
+
+      - name: Create or update workflow_runs.json
+        run: |
+          if [ ! -f workflow_runs.json ]; then
+            echo "[]" > workflow_runs.json
+          fi
+          workflow_run=$(jq -n --arg id "${{ github.run_id }}" --arg repoUrl "${{ github.event.inputs.repoUrl }}" --arg branchName "${{ github.event.inputs.branchName }}" --arg docs_repo_name "${{ env.docs_repo_name }}" --arg status "${{ job.status }}" --arg conclusion "${{ job.conclusion }}" --arg created_at "${{ github.event.created_at }}" '{id: $id, repoUrl: $repoUrl, branchName: $branchName, docs_repo_name: $docs_repo_name, status: $status, conclusion: $conclusion, created_at: $created_at}')
+          jq ". += [$workflow_run]" workflow_runs.json > tmp.json && mv tmp.json workflow_runs.json
+
+      - name: Commit and push workflow_runs.json
+        run: |
+          git config --global user.email "code2docs-ai@leansoftx.com"
+          git config --global user.name "code2docs-ai agent"
+          git add workflow_runs.json
+          git commit -m "Update workflow_runs.json"
+          git push https://code2docs-ai:${{ secrets.MY_PAT }}@github.com/${{ github.repository }}.git main

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ The workflow now includes additional steps to activate the python environment, r
    aise-cli repo parse-repo --repo_path  aise-cli repo parse-repo --repo_name <source_repo absolute>
    ```
 
-### Created by code2repo ai
+### Storing Workflow Run State
 
-This repository was created by code2repo ai.
+The workflow now includes functionality to store the state of workflow runs in a JSON file named `workflow_runs.json`. This file includes the following values for each workflow run:
+- Workflow run id
+- `repoUrl` and `branchName` from the input parameters
+- `docs_repo_name`
+- Current status and conclusion
+- Workflow run created time
+
+The `workflow_runs.json` file is created or updated during each workflow run, and the new record of the current workflow run is added to the existing content of the file. The file is then committed and pushed to the repository.


### PR DESCRIPTION
Related to #27

Add functionality to store the state of workflow runs in a JSON file.

* **README.md**
  - Add a new section to describe the functionality related to storing the state of workflow runs in a JSON file.
  - Mention the `workflow_runs.json` file and the values it includes.

* **.github/workflows/create-repo.yml**
  - Add a step to clone the current repository.
  - Add a step to create or update the `workflow_runs.json` file.
  - Add a step to commit and push the `workflow_runs.json` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/code2docs-ai/code2docs-ai-core/pull/28?shareId=24f3eed1-dcf3-4799-b20f-287fbea77b0f).