### PR TITLE
Improve .github/workflows/create-repo.yml state storage by adding the latest record at the top of the file

### DIFF
--- a/.github/workflows/create-repo.yml
+++ b/.github/workflows/create-repo.yml
@@ -54,7 +54,7 @@ jobs:
             echo "[]" > workflow_runs.json
           fi
           workflow_run=$(jq -n --arg id "${{ github.run_id }}" --arg repoUrl "${{ github.event.inputs.repoUrl }}" --arg branchName "${{ github.event.inputs.branchName }}" --arg docs_repo_name "${{ env.docs_repo_name }}" --arg status "${{ job.status }}" --arg conclusion "${{ job.conclusion }}" --arg created_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" '{id: $id, repoUrl: $repoUrl, branchName: $branchName, docs_repo_name: $docs_repo_name, status: $status, conclusion: $conclusion, created_at: $created_at}')
-          jq ". += [$workflow_run]" workflow_runs.json > tmp.json && mv tmp.json workflow_runs.json
+          jq ". = [$workflow_run] + ." workflow_runs.json > tmp.json && mv tmp.json workflow_runs.json
           git config --global user.email "code2docs-ai@leansoftx.com"
           git config --global user.name "code2docs-ai agent"
           git add workflow_runs.json

--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ The workflow now includes functionality to store the state of workflow runs in a
 - Current status and conclusion
 - Workflow run created time
 
-The `workflow_runs.json` file is created or updated during each workflow run, and the new record of the current workflow run is added to the existing content of the file. The file is then committed and pushed to the repository.
+The `workflow_runs.json` file is created or updated during each workflow run, and the new record of the current workflow run is added to the top of the existing content of the file. The file is then committed and pushed to the repository.


### PR DESCRIPTION
Related to #31

Update `.github/workflows/create-repo.yml` to prepend new workflow run records to `workflow_runs.json`.

* **README.md**
  - Update the "Storing Workflow Run State" section to reflect the new behavior of adding the latest record at the top of the `workflow_runs.json` file.

* **.github/workflows/create-repo.yml**
  - Modify the step that updates `workflow_runs.json` to prepend the new workflow run record to the file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/code2docs-ai/code2docs-ai-core/pull/32?shareId=e329296b-ca64-44c2-9d4b-ce334d75b137).