### PR TITLE
Update workflow_runs.json at the end of the workflow

### DIFF
--- a/.github/workflows/create-repo.yml
+++ b/.github/workflows/create-repo.yml
@@ -121,4 +121,12 @@ jobs:
           git add .
           git commit -m "Generate document for ${{ env.repoName }}"
           git push https://code2docs-ai:${{ secrets.MY_PAT }}@github.com/code2docs-ai/${{ env.docs_repo_name }}.git main
-          
+
+      - name: Update workflow run state
+        run: |
+          cd code2docs-ai-core
+          workflow_run=$(jq --arg id "${{ github.run_id }}" --arg status "completed" --arg completed_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" 'map(if .id == $id then .status = $status | .completed_at = $completed_at else . end)' workflow_runs.json)
+          echo "$workflow_run" > workflow_runs.json
+          git add workflow_runs.json
+          git commit -m "Update workflow_runs.json with completed status"
+          git push https://code2docs-ai:${{ secrets.MY_PAT }}@github.com/${{ github.repository }}.git main

--- a/README.md
+++ b/README.md
@@ -86,3 +86,7 @@ The workflow now includes functionality to store the state of workflow runs in a
 - Workflow run created time
 
 The `workflow_runs.json` file is created or updated during each workflow run, and the new record of the current workflow run is added to the top of the existing content of the file. The file is then committed and pushed to the repository.
+
+### Updating Workflow Run State
+
+The workflow now includes a step at the end to update the `workflow_runs.json` file with the status set to 'completed' and the 'completed_at' field with the current time. This ensures that the workflow run state is accurately recorded and updated.


### PR DESCRIPTION
Related to #33

Add a step to update the workflow run state in `.github/workflows/create-repo.yml`.

* **Update workflow run state**
  - Add a new step at the end of the workflow to update the `workflow_runs.json` file.
  - Update the status to 'completed' and add the 'completed_at' field with the current time.
  - Commit and push the updated `workflow_runs.json` file to the repository.

* **Documentation**
  - Add a note in `README.md` about updating the `workflow_runs.json` file at the end of the workflow.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/code2docs-ai/code2docs-ai-core/pull/34?shareId=d681a7f7-617d-41e8-ac8b-1dac2a87e76c).